### PR TITLE
Fix Mesh Conversion Bug & Update Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ python inference.py --exp_name /tmp/shapenet_chair_test --config configs/shapene
 For the generated results, we provide a script to convert the generated GaussianCube to mesh following [LGM](https://github.com/3DTopia/LGM). First, install additional dependencies:
 
 ```bash
-# for mesh extraction
+# for mesh extraction, uv unwarping, exportation
 pip install nerfacc
 pip install git+https://github.com/NVlabs/nvdiffrast
+# for building nvdiffrast plugins (ubuntu example)
+sudo apt install libegl1 libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa
+pip install tyro PyMCubes==0.1.2 pymeshlab ninja pygltflib xatlas scikit-learn
 # install diff_gauss for alpha rendering
 git clone --recurse-submodules https://github.com/slothfulxtx/diff-gaussian-rasterization.git 
 cd diff-gaussian-rasterization

--- a/dataset/dataset_render.py
+++ b/dataset/dataset_render.py
@@ -60,9 +60,8 @@ class InferenceDataset(Dataset):
         return data_dict
         
 
-def load_cam(c2w, class_cond=False):
+def load_cam(c2w, class_cond=False, orig_image_size=512):
     fovx = 0.8575560450553894 if not class_cond else 0.6911112070083618
-    orig_image_size = 512
     # change from OpenGL/Blender camera axes (Y up, Z back) to COLMAP (Y down, Z forward)
     c2w[:3, 1:3] *= -1
     # get the world-to-camera transform and set R, T


### PR DESCRIPTION
Thanks for your excellent work :) 

When I was running the inference according to readme instructions, some packagings are missing 
(e.g. xatlas for uv unwarping, pymeshlab for decimation, PyMCubes for marching cubes, ninja for building libs) 

So I add some requirements here, and also a small bug on `load_cam`, called here: https://github.com/GaussianCube/GaussianCube/blob/f76dc193ac074de3d0446ca56d18f7f3088980ca/scripts/convert_mesh.py#L129